### PR TITLE
ci: add golangci-lint v2 checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,26 @@
+name: Actions Security
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    name: Actions Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.56.6
+      - name: Check action pinning
+        run: pinact run --check
+      - name: Audit workflows
+        run: zizmor --format github .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-          cache: false
       - name: Test
         run: go test ./...
 
@@ -36,7 +35,6 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-          cache: false
       - name: Install aqua tools
         uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Test
+        run: go test ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e # v4.0.5
+        with:
+          aqua_version: v2.56.6
+      - name: Lint
+        run: golangci-lint run ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,8 @@
+registries:
+  - type: standard
+    ref: v4.554.0
+
+packages:
+  - name: golangci/golangci-lint@v2.13.1
+  - name: suzuki-shunsuke/pinact@v4.1.1
+  - name: zizmorcore/zizmor@v1.29.0


### PR DESCRIPTION
## Summary
- pin golangci-lint v2.13.1, pinact v4.1.1, and zizmor v1.29.0 with aqua
- add golangci-lint v2 configuration with gofmt and goimports formatter checks
- add push and pull_request CI for tests, lint, formatting, and Actions security checks
- pin all GitHub Actions to full commit SHAs and disable checkout credential persistence
- keep the repository Go version unchanged: go.mod remains the source of truth at Go 1.19; no existing Go 1.27 setting was present

## Validation
- aqua install
- golangci-lint config verify
- golangci-lint run --allow-parallel-runners ./... (0 issues; flag used locally because another runner held the shared lock)
- go test ./...
- pinact run --check
- zizmor --format github .
- git diff --check