### PR TITLE
ci: pass GitHub tokens to security checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -22,5 +22,9 @@ jobs:
           aqua_version: v2.56.6
       - name: Check action pinning
         run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Audit workflows
         run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Pass the GitHub token using environment variables supported by pinact and zizmor.
- Keep the existing read-only workflow permissions.

## Verification

- `pinact run --check`
- `zizmor --format github .`
